### PR TITLE
Support IE11 by adding a polyfill for the EventSource API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "debug": "^4.3.1",
         "drag-drop": "^6.1.0",
         "ejs": "^3.1.5",
+        "event-source-polyfill": "^1.0.26",
         "express": "^4.17.1",
         "express-mysql-session": "^2.1.4",
         "express-promise-router": "^4.0.1",
@@ -6528,6 +6529,11 @@
         "d": "1",
         "es5-ext": "~0.10.14"
       }
+    },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.26.tgz",
+      "integrity": "sha512-IwDLs9fUTcGAyacHBeS53T8wcEkDyDn0UP4tfQqJ4wQP8AyH0mszuQf2ULTylnpI0sMquzJ4usrNV7+uztwI9A=="
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
@@ -23117,6 +23123,11 @@
         "d": "1",
         "es5-ext": "~0.10.14"
       }
+    },
+    "event-source-polyfill": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.26.tgz",
+      "integrity": "sha512-IwDLs9fUTcGAyacHBeS53T8wcEkDyDn0UP4tfQqJ4wQP8AyH0mszuQf2ULTylnpI0sMquzJ4usrNV7+uztwI9A=="
     },
     "event-target-shim": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "debug": "^4.3.1",
     "drag-drop": "^6.1.0",
     "ejs": "^3.1.5",
+    "event-source-polyfill": "^1.0.26",
     "express": "^4.17.1",
     "express-mysql-session": "^2.1.4",
     "express-promise-router": "^4.0.1",

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -6,10 +6,14 @@ import dragDrop from 'drag-drop'
 import fileToArrayBuffer from 'file-to-array-buffer'
 import unmuteIosAudio from 'unmute-ios-audio'
 import colorSchemeChange from 'color-scheme-change'
+import { NativeEventSource, EventSourcePolyfill } from 'event-source-polyfill'
 
 import createStore from '../store'
 import debug from '../lib/debug-helper'
 import getProvider from '../views/provider'
+
+// Set as global property
+global.EventSource = NativeEventSource || EventSourcePolyfill
 
 const root = document.getElementById('root')
 const { store, dispatch } = createStore(update)


### PR DESCRIPTION
One of our paying enterprise customers requires that we support Internet Explorer 11 (IE11). Right now, the only API we're using that does not work on IE11 is the `EventSource` API.

This PR add a polyfill for the `EventSource` API so that our web app will work on browsers that are missing this API. We use the `event-source-polyfill` package to implement the polyfill.

This package has 516,742 weekly downloads so it should be reliable and safe.