### PR TITLE
Add support for browserslist tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.12.1",
         "@babel/plugin-transform-react-jsx": "^7.12.7",
         "@babel/register": "^7.12.1",
+        "browserlist": "^1.0.1",
         "classnames": "^2.2.6",
         "color-scheme-change": "^1.0.1",
         "common-tags": "^1.8.0",
@@ -3021,6 +3022,17 @@
       "dev": true,
       "dependencies": {
         "pako": "~1.0.5"
+      }
+    },
+    "node_modules/browserlist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserlist/-/browserlist-1.0.1.tgz",
+      "integrity": "sha512-nYq9jiWv+qXcgrJxQzivfEc7Wo2GvAKkeRViE5L3cUJpq4SZO6NZR710I/8T+OjE5BPECbzpm8rpUkwslE3nTg==",
+      "dependencies": {
+        "chalk": "^2.4.1"
+      },
+      "bin": {
+        "browserlist": "cli.js"
       }
     },
     "node_modules/browserslist": {
@@ -20225,6 +20237,14 @@
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
+      }
+    },
+    "browserlist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserlist/-/browserlist-1.0.1.tgz",
+      "integrity": "sha512-nYq9jiWv+qXcgrJxQzivfEc7Wo2GvAKkeRViE5L3cUJpq4SZO6NZR710I/8T+OjE5BPECbzpm8rpUkwslE3nTg==",
+      "requires": {
+        "chalk": "^2.4.1"
       }
     },
     "browserslist": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
     "babel": false,
     "compileEnhancements": false
   },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "maintained node versions"
+  ],
   "babel": {
     "plugins": [
       "@babel/plugin-transform-modules-commonjs",
@@ -67,6 +72,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "@babel/plugin-transform-react-jsx": "^7.12.7",
     "@babel/register": "^7.12.1",
+    "browserlist": "^1.0.1",
     "classnames": "^2.2.6",
     "color-scheme-change": "^1.0.1",
     "common-tags": "^1.8.0",


### PR DESCRIPTION
This PR adds support for [Browserslist](https://browserslist.dev) so all our frontend build tooling will know which browsers we support.

> Browserslist is a tool that allows specifying which browsers should be supported in our frontend app by specifying "queries" in a config file. It's used by frameworks/libraries such as React, Angular and Vue, but it's not limited to them.